### PR TITLE
feat: restructure workflows to have only 1 job

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -12,15 +12,11 @@ env:
   CLOUD_RUN_SERVICE: 'deploydocus-demo'
 
 jobs:
-  build:
+  build-and-deploy:
     environment: demo
     permissions:
       contents: 'read'
       id-token: 'write'
-    outputs:
-      version: ${{ steps.generate-version.outputs.version }}
-      image_name: ${{ steps.generate-image-name.outputs.image_name }}
-
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -49,27 +45,10 @@ jobs:
         run: |-
             docker build -t "${{ steps.generate-image-name.outputs.image_name }}" --build-arg build_date=$(date +%Y-%m-%d) --build-arg version=${{ steps.generate-version.outputs.version }} ./
             docker push "${{ steps.generate-image-name.outputs.image_name }}"
-
-  deploy:
-    needs: build
-    environment: demo
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-
-    runs-on: ubuntu-latest
-    steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
-          service_account: '${{ secrets.SERVICE_ACCOUNT}}'
-          token_format: 'access_token'
       - id: 'deploy'
         name: 'Deploy to Cloud Run'
         uses: 'google-github-actions/deploy-cloudrun@v2'
         with:
           service: '${{ env.CLOUD_RUN_SERVICE }}'
           region: '${{ env.REGION }}'
-          image: '${{ needs.build.outputs.image_name }}'
+          image: '${{ steps.generate-version.outputs.image_name }}'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,7 +16,7 @@ env:
   CLOUD_RUN_SERVICE: 'deploydocus'
         
 jobs:
-  retag:
+  retag-and-deploy:
     if: |
       github.event.pull_request.merged == true &&
       startsWith(github.head_ref, 'deploy-prod-')
@@ -25,8 +25,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    outputs:
-      prod_image_name: ${{ steps.generate-image-names.outputs.prod_image_name }}
     steps:
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
@@ -56,27 +54,10 @@ jobs:
         run: |
           docker tag ${{ steps.generate-image-names.outputs.image_name }} ${{ steps.generate-image-names.outputs.prod_image_name }}
           docker push ${{ steps.generate-image-names.outputs.prod_image_name }}
-
-  deploy:
-    needs: retag
-    environment: demo
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-
-    runs-on: ubuntu-latest
-    steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
-          service_account: '${{ secrets.SERVICE_ACCOUNT}}'
-          token_format: 'access_token'
       - id: 'deploy'
         name: 'Deploy to Cloud Run'
         uses: 'google-github-actions/deploy-cloudrun@v2'
         with:
           service: '${{ env.CLOUD_RUN_SERVICE }}'
           region: '${{ env.REGION }}'
-          image: '${{ needs.retag.outputs.prod_image_name }}'
+          image: '${{ steps.generate-image-names.outputs.prod_image_name }}'

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -19,7 +19,7 @@ env:
   CLOUD_RUN_SERVICE: 'deploydocus-staging'
 
 jobs:
-  build:
+  build-and-deploy:
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'deploy to staging')
@@ -62,23 +62,6 @@ jobs:
         run: |-
           docker build -t "${{ steps.generate-image-name.outputs.image_name }}" --build-arg build_date=$(date +%Y-%m-%d) --build-arg version=${{ steps.generate-version.outputs.version }} ./
           docker push "${{ steps.generate-image-name.outputs.image_name }}"
-  
-  deploy:
-    needs: build
-    environment: staging
-    runs-on: ubuntu-latest
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-
-    steps:
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: '${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}'
-          service_account: '${{ secrets.SERVICE_ACCOUNT}}'
-          token_format: 'access_token'
       - id: 'deploy'
         name: 'Deploy to Cloud Run'
         uses: 'google-github-actions/deploy-cloudrun@v2'


### PR DESCRIPTION
That way there will be less elements on PR UI when checks are being done whether or not to skip the job:

<img width="876" alt="Screenshot 2025-02-26 at 01 04 38" src="https://github.com/user-attachments/assets/1c1ad212-938a-47f1-bfed-2646ebe76f06" />
